### PR TITLE
Fix uno error (too many buttons)

### DIFF
--- a/src/main/kotlin/dev/schlaubi/musicbot/module/uno/game/player/PlayerUI.kt
+++ b/src/main/kotlin/dev/schlaubi/musicbot/module/uno/game/player/PlayerUI.kt
@@ -11,6 +11,7 @@ import dev.schlaubi.musicbot.module.uno.game.ui.translationKey
 import dev.schlaubi.uno.UnoColor
 import dev.schlaubi.uno.cards.PlayedCard
 import dev.schlaubi.uno.dropIdentical
+import dev.schlaubi.uno.transform
 
 suspend fun DiscordUnoPlayer.updateControls(active: Boolean) {
     controls.edit {
@@ -21,12 +22,12 @@ suspend fun DiscordUnoPlayer.updateControls(active: Boolean) {
             .mapIndexed { index, card -> card to index } // save origin index
             .sortedBy { (card) ->
                 (card as? PlayedCard)?.color ?: UnoColor.GREEN
-            }.chunked(1).map {
-                if (it.size > 20) {
-                    return@map it.dropIdentical().subList(0, 20)
+            }.transform {
+                if (this.size > 20) {
+                    return@transform this.dropIdentical().subList(0, 20)
                 }
-                return@map it
-            }.first().chunked(5) // Only 5 buttons per action row
+                return@transform this
+            }.chunked(5) // Only 5 buttons per action row
 
         cards.forEach {
             actionRow {

--- a/src/main/kotlin/dev/schlaubi/musicbot/module/uno/game/player/PlayerUI.kt
+++ b/src/main/kotlin/dev/schlaubi/musicbot/module/uno/game/player/PlayerUI.kt
@@ -10,6 +10,7 @@ import dev.schlaubi.musicbot.module.uno.game.ui.emoji
 import dev.schlaubi.musicbot.module.uno.game.ui.translationKey
 import dev.schlaubi.uno.UnoColor
 import dev.schlaubi.uno.cards.PlayedCard
+import dev.schlaubi.uno.dropIdentical
 
 suspend fun DiscordUnoPlayer.updateControls(active: Boolean) {
     controls.edit {
@@ -20,8 +21,12 @@ suspend fun DiscordUnoPlayer.updateControls(active: Boolean) {
             .mapIndexed { index, card -> card to index } // save origin index
             .sortedBy { (card) ->
                 (card as? PlayedCard)?.color ?: UnoColor.GREEN
-            }
-            .chunked(5) // Only 5 buttons per action row
+            }.chunked(1).map {
+                if (it.size > 20) {
+                    return@map it.dropIdentical().subList(0, 20)
+                }
+                return@map it
+            }.first().chunked(5) // Only 5 buttons per action row
 
         cards.forEach {
             actionRow {

--- a/uno/src/main/kotlin/dev/schlaubi/uno/Utils.kt
+++ b/uno/src/main/kotlin/dev/schlaubi/uno/Utils.kt
@@ -1,5 +1,6 @@
 package dev.schlaubi.uno
 
+import dev.schlaubi.uno.cards.Card
 import java.util.LinkedList
 
 /**
@@ -9,5 +10,17 @@ import java.util.LinkedList
 public fun <T> LinkedList<T>.poll(amount: Int): List<T> = buildList(amount) {
     repeat(amount) {
         add(poll())
+    }
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+public fun <T : Pair<Card, Int>> List<T>.dropIdentical(): List<Pair<Card, Int>> = buildList<Pair<Card, Int>> {
+    val cards = mutableListOf<Card>()
+
+    this@dropIdentical.forEach { pair ->
+        if (!cards.map { it.javaClass }.contains(pair.first.javaClass)) {
+            cards.add(pair.first)
+            add(pair)
+        }
     }
 }

--- a/uno/src/main/kotlin/dev/schlaubi/uno/Utils.kt
+++ b/uno/src/main/kotlin/dev/schlaubi/uno/Utils.kt
@@ -2,6 +2,9 @@ package dev.schlaubi.uno
 
 import dev.schlaubi.uno.cards.Card
 import java.util.LinkedList
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * Polls [amount] items from this [LinkedList].
@@ -13,6 +16,9 @@ public fun <T> LinkedList<T>.poll(amount: Int): List<T> = buildList(amount) {
     }
 }
 
+/**
+ * Drops identical [Card]s from a [List].
+ */
 @OptIn(ExperimentalStdlibApi::class)
 public fun <T : Pair<Card, Int>> List<T>.dropIdentical(): List<Pair<Card, Int>> = buildList<Pair<Card, Int>> {
     val cards = mutableListOf<Card>()
@@ -23,4 +29,12 @@ public fun <T : Pair<Card, Int>> List<T>.dropIdentical(): List<Pair<Card, Int>> 
             add(pair)
         }
     }
+}
+
+@OptIn(ExperimentalContracts::class)
+public inline fun <T> T.transform(block: T.() -> T): T {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+    return block()
 }


### PR DESCRIPTION
As discord only accepts 5 action rows, the bot will blame Discord when a player reaches 21 cards. And because I love Discord, I've fixed this and the bot will no longer blame the wrong organisation. (Untested because this is just a little fix and I don't have time, should work though)

Oh and I wouldn't mind if you could add the `hacktoberfest-accepted` label :>